### PR TITLE
Add init.vim save location for Flatpak install

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.
 curl -fLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
+Create init.vim in `~/.var/app/io.neovim.nvim/config/nvim/`
 
 ###### Windows (PowerShell)
 


### PR DESCRIPTION
This is an update to this issue: https://github.com/junegunn/vim-plug/pull/846

The line specifying the init.vim location for the Flatpak install was missing in the [original commit](https://github.com/junegunn/vim-plug/commit/8846bc6af14d105d3c1121bb5c42fb2efc4dfe9e) for this issue.

<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

Describe the details of your PR ...
